### PR TITLE
Small fixes

### DIFF
--- a/delay.c
+++ b/delay.c
@@ -17,7 +17,7 @@
 #include "delay.h"
 
 //busy wait delay loop. not 100% accurate
-static void delay_ms(uint16_t ms) {
+void delay_ms(uint16_t ms) {
     #define DELAY_MS_LOOP_A 86
     #define DELAY_MS_LOOP_B 30
 
@@ -42,7 +42,7 @@ static void delay_ms(uint16_t ms) {
 
 //busy wait delay loop
 //this is more or less accurate
-static void delay_us(uint16_t us) {
+void delay_us(uint16_t us) {
     #define DELAY_US_LOOP 1
 
     while(us--){

--- a/main.c
+++ b/main.c
@@ -29,7 +29,13 @@
 #include "adc.h"
 #include "wdt.h"
 #include "storage.h"
+
+#if SBUS_ENABLED
+#include "sbus.h"
+#else
 #include "ppm.h"
+#endif
+
 #include "apa102.h"
 #include "failsafe.h"
 
@@ -62,7 +68,7 @@ void main(void) {
     //init adc
     adc_init();
 
-    //init ppm output
+    //init output
     #if SBUS_ENABLED
     sbus_init();
     #else


### PR DESCRIPTION
Hey, made 2 small fixes. 
1. The one in main.c I think is very straight forward, there is a missing include header for SBUS, fixes these compiler warnings:
   
   ```
   main.c:73: warning 112: function 'sbus_init' implicit declaration
   main.c:73: warning 84: 'auto' variable 'sbus_init' may be used before initialization
   main.c:73: warning 84: 'auto' variable 'sbus_init' may be used before initialization
   ```
2. In delay.c I'm not 100% sure... removed static from both functions, to fix this issue when compiling on Windows [SDCC 3.5.0 #9253 (Jun 20 2015) (MINGW64)]:
   
   ```
   delay.c:20: error 146: two or more storage classes in declaration for 'delay_ms'
   delay.c:45: error 146: two or more storage classes in declaration for 'delay_us'
   ```
   
   With no changes it compiled only in Linux [SDCC 3.3.0 #8604 (Dec 30 2013) (Linux) - Ubuntu], and after the change the generated main.hex are identical (could not test this on Windows), so I guess it should be fine also.

Hope it helps ;)
