### PR TITLE
Add a note about the raspberry pi fork of CC2510Lib

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,9 @@ You will need a CC debugger or an arduino flashed with this code in order to pro
 https://github.com/fishpepper/CC2510Lib
 (theres a python script to flash the cc2510 in that repo as well)
 
+Alternatively, you can use a raspberry pi to flash. This does not require any voltage dividers:
+https://github.com/jimmyw/CC2510Lib
+
 Connections:
 
 It is handy to mount a 5pin Molex Picoblade connector to the


### PR DESCRIPTION
Hi @fishpepper.

I got stuck trying to flash my VDM5 with my Arduino. Not really sure why, but i did not manage the flash tool to communicate to the Arduino.

Instead i forked your code, and rewrite it to use a raspberry pi, and flash using its 3.3v gpio. This worked really good for me, and it is very speedy and required no voltage dividers. Now my microquad works perfect using S.BUS 👍 

If you want, you can add a note to your README about this, so other users also can try it out.

Thanks again for your work, and the d4r_porting looks promising. If i got time, i am going to try to flash my x4r, i guess it is very minor differences in hardware.

Keep up the good work!!
