### PR TITLE
sharing sbus with telemetry d4rii

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #select target. supported: {VD5M, D4RII, USKY, TINYFISH, AFRX, RASP}
-TARGET ?= USKY
+TARGET ?= D4RII
 
 ASFLAGS       = -g
 ROOT         := $(patsubst %/,%,$(dir $(lastword $(MAKEFILE_LIST))))

--- a/README.md
+++ b/README.md
@@ -184,9 +184,24 @@ Connect an inverted serial cable to the 4pin connector (FTDI devices can be conf
 [4] = inverted RX ---> connect to TX
 </pre>
 
+Non-inverted way.
+<pre>
+GND
+POWER
+rx/tx before the rx and tx signal inverters on the d4rii (picture in post of rcgroups forum)
+</pre>
+
 TODO: add flash command to makefile/doc
 
 # Random notes:
+objcopy -O ihex obj/opensky_d4rii.elf obj/opensky_D4RII.hex	 							// turns elf into hex after compiling, in obj folder
+
+flashing via stm32flash-0.5 from command promt..
+
+.\stm32flash.exe -k -b 57600 -m 8e1 COM16					 							          // unlock flash
+
+.\stm32flash.exe -w opensky_D4RII.hex -n 20 -b 57600 -m 8e1 COM16 				// to flash opensky_d4rii.hex
+
 
 Just in case you need to mount a new antenna: My vd5m came with a 3.5cm antenna wire. However it should be 31.5mm long (1/4 wavelength at 2.4GHz)
 

--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Serial Port:
 (Pin 1 = left = the same side as the LEDs)
 [1] = GND
 [2] = AD2 input (max 3.3V!)
-[3] = inverted SBUS (if enabled in main.h) or Debug UART 
-[4] = NC
+[3] = inverted SBUS (if enabled in main.h) or Debug UART if debug on
+[4] = telemetry frsky if enabled (either inverted 9600buad or inverted shared sbus @ sbus buad rate)
 </pre>
 
 ## rasp

--- a/arch/stm32f1/hal_soft_serial.c
+++ b/arch/stm32f1/hal_soft_serial.c
@@ -28,6 +28,8 @@
 #include "stm32f10x_tim.h"
 #include "misc.h"  // stm32 nvic
 
+#ifndef HUB_TELEMETRY_ON_SBUS_UART
+
 void hal_soft_serial_init(void) {
     hal_soft_serial_init_gpio();
     hal_soft_serial_init_rcc();
@@ -185,4 +187,4 @@ void SOFT_SERIAL_TIMER_UP_IRQHandler(void) {
     }
 }
 
-
+#endif  // if not HUB_TELEMETRY_ON_SBUS_UART

--- a/arch/stm32f1/hal_uart.c
+++ b/arch/stm32f1/hal_uart.c
@@ -28,6 +28,7 @@
 #include "stm32f10x_gpio.h"
 #include "stm32f10x_rcc.h"
 #include "misc.h"  // this defines stm32 nvic stuff
+#include "uart.h" 
 
 #ifdef SBUS_ENABLED
 

--- a/board/d4rii/config.h
+++ b/board/d4rii/config.h
@@ -17,13 +17,19 @@
 #define SBUS_INVERTED
 
 // PPM (only used if sbus is disabled)
-// invert SBUS output (normal is non inverted)
 // #define PPM_INVERTED
 
-// hub telemetry input (soft serial)
-// #define HUB_TELEMETRY_ON_SBUS_UART
-// #define HUB_TELEMETRY_INVERTED 
-// #define PPM_INVERTED
+// hub telemetry input (soft serial if only HUB_TELEMETRY_INVERTED, sbus uart if HUB_TELEMETRY_ON_SBUS_UART)
+#define HUB_TELEMETRY_ON_SBUS_UART  //  rx pin on side if inverted
+#define HUB_TELEMETRY_INVERTED 
+
+// if #define SBUS_ENABLED, #define SBUS_INVERTED, #define HUB_TELEMETRY_ON_SBUS_UART, and #define HUB_TELEMETRY_INVERTED
+// you can share the rx/tx side uart with the sbus tx and telemetry rx both with inverted signals on betaflight uart set to RX, frsky telemetry, and autobuad
+// for frsky. cuts down the uart usage from two to one, and also will have telemetry while disarmed!
+// ***have not tested non-inverted yet***
+
+//  debugging
+// #define DEBUG_ME
 
 #ifdef SBUS_INVERTED
     // DEBUG is on SERVO4 output:
@@ -163,24 +169,25 @@
 #define SOFT_SPI_MOSI             GPIO_Pin_1
 #define SOFT_SPI_SCK              GPIO_Pin_2
 
+#ifndef HUB_TELEMETRY_ON_SBUS_UART
 // hub telemetry input NOTE: this has to be a timer io
-#define SOFT_SERIAL_PIN_HAS_INVERTER  // there is an inverter on GPIOA.10!
-#define SOFT_SERIAL_GPIO          GPIOA
-#define SOFT_SERIAL_CLK           RCC_APB2Periph_GPIOA
-#define SOFT_SERIAL_CLK_RCC       2
-#define SOFT_SERIAL_PIN           GPIO_Pin_10
-#define SOFT_SERIAL_TIMER         TIM1
-#define SOFT_SERIAL_TIMER_CLK     RCC_APB2Periph_TIM1
-#define SOFT_SERIAL_TIMER_CLK_RCC 2
-#define SOFT_SERIAL_TIMER_IT_IC   TIM_IT_CC3
-#define SOFT_SERIAL_TIMER_CH      TIM_Channel_3
-#define SOFT_SERIAL_TIMER_GET_CAPTURE()  TIM_GetCapture3(SOFT_SERIAL_TIMER)
-#define SOFT_SERIAL_TIMER_IT_UP   TIM_IT_Update
-#define SOFT_SERIAL_TIMER_IC_IRQHandler TIM1_CC_IRQHandler
-#define SOFT_SERIAL_TIMER_UP_IRQHandler TIM1_UP_TIM16_IRQHandler
-#define SOFT_SERIAL_TIMER_IC_IRQn TIM1_CC_IRQn
-#define SOFT_SERIAL_TIMER_UP_IRQn TIM1_UP_IRQn
-
+  #define SOFT_SERIAL_PIN_HAS_INVERTER  // there is an inverter on GPIOA.10!
+  #define SOFT_SERIAL_GPIO          GPIOA
+  #define SOFT_SERIAL_CLK           RCC_APB2Periph_GPIOA
+  #define SOFT_SERIAL_CLK_RCC       2
+  #define SOFT_SERIAL_PIN           GPIO_Pin_10
+  #define SOFT_SERIAL_TIMER         TIM1
+  #define SOFT_SERIAL_TIMER_CLK     RCC_APB2Periph_TIM1
+  #define SOFT_SERIAL_TIMER_CLK_RCC 2
+  #define SOFT_SERIAL_TIMER_IT_IC   TIM_IT_CC3
+  #define SOFT_SERIAL_TIMER_CH      TIM_Channel_3
+  #define SOFT_SERIAL_TIMER_GET_CAPTURE()  TIM_GetCapture3(SOFT_SERIAL_TIMER)
+  #define SOFT_SERIAL_TIMER_IT_UP   TIM_IT_Update
+  #define SOFT_SERIAL_TIMER_IC_IRQHandler TIM1_CC_IRQHandler
+  #define SOFT_SERIAL_TIMER_UP_IRQHandler TIM1_UP_TIM16_IRQHandler
+  #define SOFT_SERIAL_TIMER_IC_IRQn TIM1_CC_IRQn
+  #define SOFT_SERIAL_TIMER_UP_IRQn TIM1_UP_IRQn
+#endif // hub telemetry on softserial
 
 // THIS CONFIGURES IRQ PRIORITIES - DO NOT MESS THIS UP!
 // this is the most critical stuff:

--- a/src/main.h
+++ b/src/main.h
@@ -23,7 +23,11 @@
 #include "hal_defines.h"
 
 // debugging data
-#define DEBUG 1
+#ifdef DEBUG_ME
+  #define DEBUG 1
+#else
+  #define DEBUG 0
+#endif  //  if debug or not
 
 // useful for debugging. DO NOT USE!
 #define ADC_DO_TEST 0


### PR DESCRIPTION
fixes for shared inverted sbus uart with inverted frsky telemetry at the same buad rate, not the normal 9600buad for frsky telemetry.

(could do non inverted of same port if soldered wires before the rx/tx inverting circuits on the d4rii, if non inverted does not work)

tested and works awesome. freed up an extra uart for me.