### PR TITLE
Adding pin for bypass functionality for new frontend chips

### DIFF
--- a/arch/cc251x/hal_cc25xx.c
+++ b/arch/cc251x/hal_cc25xx.c
@@ -54,7 +54,7 @@ void hal_cc25xx_init(void) {
       RF_ANTENNA_SELECT_A();
     #endif  // RF_ANTENNA_SWITCH_PORT
 
-    // if we support HIGH GAIN mode config in as output:
+    // if we support HIGH GAIN mode config pin as output:
     #ifdef RF_HIGH_GAIN_MODE_PORT
       PORT2DIR(RF_HIGH_GAIN_MODE_PORT) |= (1 << RF_HIGH_GAIN_MODE_PIN);
       // enable high gain mode?
@@ -64,6 +64,17 @@ void hal_cc25xx_init(void) {
         RF_HIGH_GAIN_MODE_DISABLE();
       #endif  // RF_HIGH_GAIN_MODE_ENABLED
     #endif  // RF_HIGH_GAIN_MODE_PORT
+
+    // if we support Bypass mode make sure to config the pin as output:
+    #ifdef RF_BYPASS_PORT
+      PORT2DIR(RF_BYPASS_MODE_PORT) |= (1 << RF_BYPASS_MODE_PIN);
+      // set default to Bypass off
+      #ifdef RF_BYPASS_MODE_ENABLED
+        RF_BYPASS_MODE_ENABLE();
+      #else
+        RF_BYPASS_MODE_DISABLE();
+      #endif  // RF_BYPASS_MODE_ENABLED
+    #endif  // RF_BYPASS_PORT
 }
 
 uint32_t hal_cc25xx_set_antenna(uint8_t id) {

--- a/arch/cc251x/hal_cc25xx.h
+++ b/arch/cc251x/hal_cc25xx.h
@@ -52,6 +52,11 @@
     PORT2BIT(RF_HIGH_GAIN_MODE_PORT, RF_HIGH_GAIN_MODE_PIN) = ~RF_HIGH_GAIN_MODE_ON_LEVEL; }
 #endif  // RF_HIGH_GAIN_MODE_PORT
 
+#ifdef RF_BYPASS_MODE_PORT
+  #define RF_BYPASS_MODE_ENABLE()  { PORT2BIT(RF_BYPASS_MODE_PORT, RF_BYPASS_MODE_PIN) = RF_BYPASS_MODE_ON_LEVEL; }
+  #define RF_BYPASS_MODE_DISABLE() { PORT2BIT(RF_BYPASS_MODE_PORT, RF_BYPASS_MODE_PIN) = ~RF_BYPASS_MODE_ON_LEVEL; }
+#endif  // RF_BYPASS_MODE_PORT
+
 uint32_t hal_cc25xx_set_antenna(uint8_t id);
 #define hal_cc25xx_process_packet(packet_received, buffer, maxlen) {}
 

--- a/board/afrx/config.h
+++ b/board/afrx/config.h
@@ -67,12 +67,19 @@
 #define RF_ANTENNA_SWITCH_PIN       5
 #define RF_ANTENNA_A_LEVEL          1
 
-// enable high gain?
-// #define RF_HIGH_GAIN_MODE_ENABLED
-// gain control pin
-// #define RF_HIGH_GAIN_MODE_PORT      P1
-// #define RF_HIGH_GAIN_MODE_PIN       6
-// #define RF_HIGH_GAIN_MODE_ON_LEVEL  1
+// enable High Gain?
+#define RF_HIGH_GAIN_MODE_ENABLED
+// Gain control pin
+#define RF_HIGH_GAIN_MODE_PORT      P1
+#define RF_HIGH_GAIN_MODE_PIN       6
+#define RF_HIGH_GAIN_MODE_ON_LEVEL  1
+
+// enable Bypass?
+// #define RF_BYPASS_MODE_ENABLED
+// Bypass control pin
+#define RF_BYPASS_MODE_PORT         P1
+#define RF_BYPASS_MODE_PIN          7
+#define RF_BYPASS_MODE_ON_LEVEL     1
 
 // bootloader config
 #define BOOTLOADER_LED_GREEN_PORT   LED_GREEN_PORT

--- a/board/afrx/config.h
+++ b/board/afrx/config.h
@@ -54,7 +54,7 @@
 
 // LNA control pin
 #define RF_LNA_PORT                 P1
-#define RF_LNA_PIN                  3
+#define RF_LNA_PIN                  6
 #define RF_LNA_ON_LEVEL             1
 
 // PA control pin
@@ -71,14 +71,14 @@
 #define RF_HIGH_GAIN_MODE_ENABLED
 // Gain control pin
 #define RF_HIGH_GAIN_MODE_PORT      P1
-#define RF_HIGH_GAIN_MODE_PIN       6
+#define RF_HIGH_GAIN_MODE_PIN       7
 #define RF_HIGH_GAIN_MODE_ON_LEVEL  1
 
 // enable Bypass?
 // #define RF_BYPASS_MODE_ENABLED
 // Bypass control pin
 #define RF_BYPASS_MODE_PORT         P1
-#define RF_BYPASS_MODE_PIN          7
+#define RF_BYPASS_MODE_PIN          3
 #define RF_BYPASS_MODE_ON_LEVEL     1
 
 // bootloader config


### PR DESCRIPTION
Preparation for the full range AlienFlightNG RX. Likely will be useful later to avoid swamping and can be controlled by the firmware in the future. For now, it will allow to enable or disable frontend bypass during firmware compile time only.